### PR TITLE
Add OCR for Iranian national ID cards

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# Iranian National ID OCR
+
+This project provides a minimal Python script for extracting text from Iranian national ID cards.
+It relies on [Tesseract OCR](https://github.com/tesseract-ocr/tesseract) with the Persian language data.
+
+## Setup
+
+```bash
+# install system dependencies
+apt-get update
+apt-get install -y tesseract-ocr tesseract-ocr-fas python3-pip
+
+# install Python dependencies
+pip install -r requirements.txt
+```
+
+## Usage
+
+```bash
+python iran_id_ocr.py path/to/id-card-image.jpg
+```
+
+The script will output a JSON object containing any detected fields such as the national ID number,
+birth date, and the raw OCR text.
+
+## Testing
+
+Run `pytest` to execute the test suite.

--- a/iran_id_ocr.py
+++ b/iran_id_ocr.py
@@ -1,0 +1,49 @@
+import cv2
+import pytesseract
+from PIL import Image
+import re
+
+ID_NUMBER_REGEX = re.compile(r"\b\d{10}\b")
+BIRTH_DATE_REGEX = re.compile(r"\b\d{4}/\d{2}/\d{2}\b")
+
+def preprocess_image(image_path: str):
+    """Load image and return thresholded version that highlights black text."""
+    image = cv2.imread(image_path)
+    if image is None:
+        raise FileNotFoundError(f"Image not found: {image_path}")
+    gray = cv2.cvtColor(image, cv2.COLOR_BGR2GRAY)
+    # Invert threshold to get black text as white on black background
+    _, thresh = cv2.threshold(gray, 150, 255, cv2.THRESH_BINARY_INV)
+    return thresh
+
+def ocr_image(processed_image) -> str:
+    """Run Tesseract OCR on the preprocessed image."""
+    pil_img = Image.fromarray(processed_image)
+    text = pytesseract.image_to_string(pil_img, lang="fas+eng")
+    return text
+
+def parse_fields(text: str) -> dict:
+    """Extract key data fields from OCR text."""
+    data = {}
+    id_match = ID_NUMBER_REGEX.search(text)
+    if id_match:
+        data["national_id"] = id_match.group()
+    birth_match = BIRTH_DATE_REGEX.search(text)
+    if birth_match:
+        data["birth_date"] = birth_match.group()
+    data["raw_text"] = text.strip()
+    return data
+
+def extract_iran_id_data(image_path: str) -> dict:
+    """High-level helper that returns fields extracted from an ID card image."""
+    processed = preprocess_image(image_path)
+    text = ocr_image(processed)
+    return parse_fields(text)
+
+if __name__ == "__main__":
+    import sys, json
+    if len(sys.argv) != 2:
+        print("Usage: python iran_id_ocr.py <image-path>")
+        sys.exit(1)
+    result = extract_iran_id_data(sys.argv[1])
+    print(json.dumps(result, ensure_ascii=False, indent=2))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,3 @@
+pytesseract
+opencv-python
+Pillow

--- a/tests/test_iran_id_ocr.py
+++ b/tests/test_iran_id_ocr.py
@@ -1,0 +1,16 @@
+from iran_id_ocr import extract_iran_id_data
+from PIL import Image, ImageDraw
+import tempfile
+
+def create_test_image(text: str) -> str:
+    image = Image.new("RGB", (400, 200), "white")
+    draw = ImageDraw.Draw(image)
+    draw.text((10, 80), text, fill="black")
+    temp = tempfile.NamedTemporaryFile(suffix=".png", delete=False)
+    image.save(temp.name)
+    return temp.name
+
+def test_extract_returns_text():
+    path = create_test_image("1234567890")
+    data = extract_iran_id_data(path)
+    assert isinstance(data["raw_text"], str)


### PR DESCRIPTION
## Summary
- implement `iran_id_ocr.py` using Tesseract OCR to extract text and parse national ID and birth date
- document setup and usage in README
- add requirements file and simple test harness

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68b9644fefe48326abcf33c7de0d3e4b